### PR TITLE
fix(HACBS-1648): force PipelineRuns to be created in default namespace

### DIFF
--- a/tekton/pipeline_run.go
+++ b/tekton/pipeline_run.go
@@ -44,7 +44,7 @@ func NewPipelineRun(internalRequest *v1alpha1.InternalRequest) *tektonv1beta1.Pi
 	pipelineRun := &tektonv1beta1.PipelineRun{
 		ObjectMeta: v1.ObjectMeta{
 			GenerateName: strings.ToLower(reflect.TypeOf(v1alpha1.InternalRequest{}).Name()) + "-",
-			Namespace:    internalRequest.Namespace,
+			Namespace:    "default",
 			Labels: map[string]string{
 				InternalRequestNameLabel:      internalRequest.Name,
 				InternalRequestNamespaceLabel: internalRequest.Namespace,

--- a/tekton/pipeline_run_test.go
+++ b/tekton/pipeline_run_test.go
@@ -53,6 +53,12 @@ var _ = Describe("PipelineRun", Ordered, func() {
 			Expect(newPipelineRun.Labels[InternalRequestNamespaceLabel]).To(Equal(internalRequest.Namespace))
 		})
 
+		It("should target the default namespace", func() {
+			newPipelineRun := NewPipelineRun(internalRequest)
+
+			Expect(newPipelineRun.Namespace).To(Equal("default"))
+		})
+
 		It("should reference the Pipeline specified in the InternalRequest", func() {
 			newPipelineRun := NewPipelineRun(internalRequest)
 


### PR DESCRIPTION
When the remote InternalRequest is created in a namespace different from `default`, the Internal service fails to create a PipelineRun to handle the request as it tries to use the remote namespace which doesn't exists locally.

Signed-off-by: David Moreno García <damoreno@redhat.com>