### PR TITLE
revert(HACBS-1604): add missing workspace for PRs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/operator-framework/operator-lib v0.11.0
 	github.com/redhat-appstudio/operator-goodies v0.0.0-20230113090719-a8a43f600367
 	github.com/tektoncd/pipeline v0.42.0
-	k8s.io/api v0.25.4
 	k8s.io/apimachinery v0.25.4
 	k8s.io/client-go v0.25.4
 	knative.dev/pkg v0.0.0-20221011175852-714b7630a836
@@ -90,6 +89,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/api v0.25.4 // indirect
 	k8s.io/apiextensions-apiserver v0.25.2 // indirect
 	k8s.io/component-base v0.25.2 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect

--- a/tekton/pipeline_run.go
+++ b/tekton/pipeline_run.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"github.com/redhat-appstudio/internal-services/api/v1alpha1"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 	"strings"
@@ -61,13 +60,6 @@ func NewPipelineRun(internalRequest *v1alpha1.InternalRequest, internalServicesC
 			PipelineRef: getPipelineRef(internalRequest, internalServicesConfig),
 		},
 	}
-
-	pipelineRun.Spec.Workspaces = append(pipelineRun.Spec.Workspaces, tektonv1beta1.WorkspaceBinding{
-		Name: "release-workspace",
-		PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-			ClaimName: "release-pvc",
-		},
-	})
 
 	appendInternalRequestParams(pipelineRun, internalRequest)
 


### PR DESCRIPTION
Reverts redhat-appstudio/internal-services#7

The change is not needed. If we need it in the future will have to check if App interface provides a PV and will need to define proper and configurable names.