### PR TITLE
fix(HACBS1835): add missing rbac annotations

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -49,6 +49,7 @@ rules:
   - pipelineruns
   verbs:
   - create
+  - delete
   - get
   - list
   - watch
@@ -58,3 +59,11 @@ rules:
   - pipelineruns/status
   verbs:
   - get
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelines
+  verbs:
+  - get
+  - list
+  - watch

--- a/controllers/internalrequest/controller.go
+++ b/controllers/internalrequest/controller.go
@@ -60,7 +60,8 @@ func NewInternalRequestReconciler(client client.Client, remoteClient client.Clie
 // +kubebuilder:rbac:groups=appstudio.redhat.com,resources=internalrequests/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=appstudio.redhat.com,resources=internalrequests/finalizers,verbs=update
 // +kubebuilder:rbac:groups=appstudio.redhat.com,resources=internalservicesconfigs,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns,verbs=get;list;watch;create
+// +kubebuilder:rbac:groups=tekton.dev,resources=pipelines,verbs=get;list;watch
+// +kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns,verbs=get;list;watch;create;delete
 // +kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns/status,verbs=get
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to


### PR DESCRIPTION
This commit add missing rbac annotations for Tekton resources.