### PR TITLE
fix(HACBS-2039): stop reprocessing finished requests

### DIFF
--- a/api/v1alpha1/internalrequest_types.go
+++ b/api/v1alpha1/internalrequest_types.go
@@ -85,6 +85,7 @@ type InternalRequestStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Succeeded",type=string,JSONPath=`.status.conditions[?(@.type=="InternalRequestSucceeded")].status`
 // +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="InternalRequestSucceeded")].reason`
+
 // InternalRequest is the Schema for the internalrequests API.
 type InternalRequest struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/controllers/internalrequest/adapter.go
+++ b/controllers/internalrequest/adapter.go
@@ -160,6 +160,15 @@ func (a *Adapter) EnsureRequestIsAllowed() (reconciler.OperationResult, error) {
 	return reconciler.RequeueOnErrorOrStop(a.client.Status().Patch(a.ctx, a.internalRequest, patch))
 }
 
+// EnsureRequestINotCompleted is an operation that will stop processing a request if it was completed already.
+func (a *Adapter) EnsureRequestINotCompleted() (reconciler.OperationResult, error) {
+	if a.internalRequest.HasCompleted() {
+		return reconciler.StopProcessing()
+	}
+
+	return reconciler.ContinueProcessing()
+}
+
 // EnsureStatusIsTracked is an operation that will ensure that the InternalRequest PipelineRun status is tracked
 // in the InternalRequest being processed.
 func (a *Adapter) EnsureStatusIsTracked() (reconciler.OperationResult, error) {

--- a/controllers/internalrequest/adapter_test.go
+++ b/controllers/internalrequest/adapter_test.go
@@ -234,6 +234,30 @@ var _ = Describe("PipelineRun", Ordered, func() {
 		})
 	})
 
+	Context("When calling EnsureRequestINotCompleted", func() {
+		AfterEach(func() {
+			deleteResources()
+		})
+
+		BeforeEach(func() {
+			createResources()
+		})
+
+		It("should stop processing when the InternalRequest is completed", func() {
+			adapter.internalRequest.MarkRunning()
+			adapter.internalRequest.MarkSucceeded()
+			result, err := adapter.EnsureRequestINotCompleted()
+			Expect(result.CancelRequest && !result.RequeueRequest).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
+
+		It("should continue processing when the InternalRequest is not completed", func() {
+			result, err := adapter.EnsureRequestINotCompleted()
+			Expect(!result.CancelRequest && !result.RequeueRequest).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
+	})
+
 	Context("When calling EnsureStatusIsTracked", func() {
 		AfterEach(func() {
 			deleteResources()

--- a/controllers/internalrequest/controller.go
+++ b/controllers/internalrequest/controller.go
@@ -82,6 +82,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	adapter := NewAdapter(ctx, r.Client, r.InternalClient, internalRequest, loader.NewLoader(), logger)
 
 	return reconciler.ReconcileHandler([]reconciler.ReconcileOperation{
+		adapter.EnsureRequestINotCompleted,
 		adapter.EnsureConfigIsLoaded, // This operation sets the config in the adapter to be used in other operations.
 		adapter.EnsureRequestIsAllowed,
 		adapter.EnsurePipelineExists, // This operation sets the pipeline in the adapter to be used in other operations.


### PR DESCRIPTION
Once an Internal Request was processed, a restart on the operator would force the same request to be reprocessed if the debug mode was disabled.