### PR TITLE
fix(HACBS-2551): filter cached resources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 COPY loader/ loader/
+COPY metadata/ metadata/
 COPY metrics/ metrics/
 COPY tekton/ tekton/
 

--- a/controllers/internalrequest/adapter_test.go
+++ b/controllers/internalrequest/adapter_test.go
@@ -293,7 +293,7 @@ var _ = Describe("PipelineRun", Ordered, func() {
 			pipelineRun, err := adapter.createInternalRequestPipelineRun()
 			Expect(pipelineRun).NotTo(BeNil())
 			Expect(err).To(BeNil())
-			Expect(pipelineRun.Labels).To(HaveLen(2))
+			Expect(pipelineRun.Labels).To(HaveLen(3))
 			Expect(pipelineRun.Spec.Params).To(HaveLen(len(adapter.internalRequest.Spec.Params)))
 		})
 

--- a/metadata/labels.go
+++ b/metadata/labels.go
@@ -1,0 +1,18 @@
+package metadata
+
+import "fmt"
+
+const (
+	// rhtapDomain is the prefix of the application label
+	rhtapDomain = "appstudio.openshift.io"
+)
+
+var (
+	// pipelinesLabelPrefix is the prefix of the pipelines label
+	pipelinesLabelPrefix = fmt.Sprintf("pipelines.%s", rhtapDomain)
+)
+
+var (
+	// PipelinesTypeLabel is the label used to describe the type of pipeline
+	PipelinesTypeLabel = fmt.Sprintf("%s/%s", pipelinesLabelPrefix, "type")
+)

--- a/tekton/pipeline_run.go
+++ b/tekton/pipeline_run.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	libhandler "github.com/operator-framework/operator-lib/handler"
 	"github.com/redhat-appstudio/internal-services/api/v1alpha1"
+	"github.com/redhat-appstudio/internal-services/metadata"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -31,6 +32,9 @@ import (
 const (
 	// internalRequestLabelPrefix is the prefix of the internal request labels
 	internalRequestLabelPrefix = "internal-services.appstudio.openshift.io"
+
+	// PipelineTypeRelease is the type for PipelineRuns created to run a release Pipeline
+	PipelineTypeRelease = "release"
 )
 
 var (
@@ -81,6 +85,7 @@ func (i *InternalRequestPipelineRun) WithInternalRequest(internalRequest *v1alph
 	i.ObjectMeta.Labels = map[string]string{
 		InternalRequestNameLabel:      internalRequest.Name,
 		InternalRequestNamespaceLabel: internalRequest.Namespace,
+		metadata.PipelinesTypeLabel:   PipelineTypeRelease,
 	}
 
 	return i


### PR DESCRIPTION
Too many resources were required to run this operator as we were caching every single resources. This change filter cached resources by using a new cache with custom selectors for Tekton resources.