### PR TITLE
fix(RHTAPREL-625): reject requests with non-existent Pipeline

### DIFF
--- a/controllers/internalrequest/adapter.go
+++ b/controllers/internalrequest/adapter.go
@@ -91,7 +91,7 @@ func (a *Adapter) EnsurePipelineExists() (controller.OperationResult, error) {
 
 	if err != nil {
 		patch := client.MergeFrom(a.internalRequest.DeepCopy())
-		a.internalRequest.MarkFailed(fmt.Sprintf("No endpoint to handle '%s' requests", a.internalRequest.Spec.Request))
+		a.internalRequest.MarkRejected(fmt.Sprintf("No endpoint to handle '%s' requests", a.internalRequest.Spec.Request))
 		return controller.RequeueOnErrorOrStop(a.client.Status().Patch(a.ctx, a.internalRequest, patch))
 	}
 


### PR DESCRIPTION
There was a bug caused by a call to MarkFailed as at that point the PipelineRun hadn't started yet. This commit change the code to call MarkRejected as the request should be rejected in case of the Pipeline not existing.