### PR TITLE
fix: missing renaming RoleBinding

### DIFF
--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/created-by: internal-services
     app.kubernetes.io/part-of: internal-services
     app.kubernetes.io/managed-by: kustomize
-  name: manager-rolebinding
+  name: internal-services-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
This commit fixes the roleBinding name, adding the prefix _internal-services_ to it.