### PR TITLE
feat(RELEASE-1047): pass SA to pipelineRuns

### DIFF
--- a/api/v1alpha1/internalrequest_types.go
+++ b/api/v1alpha1/internalrequest_types.go
@@ -42,6 +42,12 @@ type InternalRequestSpec struct {
 	// Timeouts defines the different Timeouts to use in the InternalRequest PipelineRun execution
 	// +optional
 	Timeouts tektonv1beta1.TimeoutFields `json:"timeouts,omitempty"`
+
+	// ServiceAccount defines the serviceAccount to use in the InternalRequest PipelineRun execution.
+	// If none is passed, the default Tekton ServiceAccount will be used
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+	// +optional
+	ServiceAccount string `json:"serviceAccount,omitempty"`
 }
 
 // InternalRequestStatus defines the observed state of InternalRequest.

--- a/config/crd/bases/appstudio.redhat.com_internalrequests.yaml
+++ b/config/crd/bases/appstudio.redhat.com_internalrequests.yaml
@@ -53,6 +53,12 @@ spec:
                   will be translated into a Tekton pipeline
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
+              serviceAccount:
+                description: ServiceAccount defines the serviceAccount to use in the
+                  InternalRequest PipelineRun execution. If none is passed, the default
+                  Tekton ServiceAccount will be used
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
               timeouts:
                 description: Timeouts defines the different Timeouts to use in the
                   InternalRequest PipelineRun execution

--- a/controllers/internalrequest/adapter_test.go
+++ b/controllers/internalrequest/adapter_test.go
@@ -315,6 +315,13 @@ var _ = Describe("PipelineRun", Ordered, func() {
 			Expect(err).To(BeNil())
 			Expect(pipelineRun.Spec.PipelineRef.Name).To(Equal(adapter.internalRequestPipeline.Name))
 		})
+
+		It("creates a PipelineRun with the proper service account", func() {
+			pipelineRun, err := adapter.createInternalRequestPipelineRun()
+			Expect(pipelineRun).NotTo(BeNil())
+			Expect(err).To(BeNil())
+			Expect(pipelineRun.Spec.ServiceAccountName).To(Equal("sample-sa"))
+		})
 	})
 
 	Context("When calling getDefaultInternalServicesConfig", func() {
@@ -430,7 +437,8 @@ var _ = Describe("PipelineRun", Ordered, func() {
 				Namespace: "default",
 			},
 			Spec: v1alpha1.InternalRequestSpec{
-				Request: "request",
+				Request:        "request",
+				ServiceAccount: "sample-sa",
 			},
 		}
 		Expect(k8sClient.Create(ctx, internalRequest)).To(Succeed())

--- a/tekton/pipeline_run.go
+++ b/tekton/pipeline_run.go
@@ -93,6 +93,8 @@ func (i *InternalRequestPipelineRun) WithInternalRequest(internalRequest *v1alph
 		i.Spec.Timeouts = &internalRequest.Spec.Timeouts
 	}
 
+	i.Spec.ServiceAccountName = internalRequest.Spec.ServiceAccount
+
 	return i
 }
 

--- a/tekton/pipeline_run_test.go
+++ b/tekton/pipeline_run_test.go
@@ -19,8 +19,9 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/konflux-ci/internal-services/api/v1alpha1"
 	"time"
+
+	"github.com/konflux-ci/internal-services/api/v1alpha1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -105,6 +106,22 @@ var _ = Describe("PipelineRun", Ordered, func() {
 			}
 
 			Expect(newInternalRequestPipelineRun.Spec.Timeouts).To(Equal(timeouts))
+		})
+
+		It("should set the ServiceAccountName for the PipelineRun", func() {
+			newInternalRequestPipelineRun := NewInternalRequestPipelineRun(internalServicesConfig)
+			newInternalRequestPipelineRun.WithInternalRequest(internalRequest)
+
+			Expect(newInternalRequestPipelineRun.Spec.ServiceAccountName).To(Equal(internalRequest.Spec.ServiceAccount))
+		})
+
+		It("should not set the ServiceAccountName for the PipelineRun if none is passed", func() {
+			newInternalRequestPipelineRun := NewInternalRequestPipelineRun(internalServicesConfig)
+			newInternalRequest := internalRequest.DeepCopy()
+			newInternalRequest.Spec.ServiceAccount = ""
+			newInternalRequestPipelineRun.WithInternalRequest(newInternalRequest)
+
+			Expect(newInternalRequestPipelineRun.Spec.ServiceAccountName).To(Equal(""))
 		})
 	})
 
@@ -195,6 +212,7 @@ var _ = Describe("PipelineRun", Ordered, func() {
 					Tasks:    &metav1.Duration{Duration: 1 * time.Hour},
 					Finally:  &metav1.Duration{Duration: 1 * time.Hour},
 				},
+				ServiceAccount: "sample-sa",
 			},
 		}
 		internalRequest.Kind = "InternalRequest"


### PR DESCRIPTION
This commit modifies the adapter to pass the release-service-account service account to the pipelineRuns created by the adapter.