### PR TITLE
feat(RELEASE-1046): add SA for executing pipelineruns

### DIFF
--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -10,3 +10,11 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release-service-account
+  namespace: system
+imagePullSecrets:
+- name: redhat-workloads-token


### PR DESCRIPTION
Add a new service account to use for our internal service pipelineruns instead of using the default pipeline SA that tekton provides.

The benefit is that we can control this one and link it to what we need.