### PR TITLE
chore(RELEASE-1347): remove manager image update from github workflow

### DIFF
--- a/.github/workflows/app_interface.yaml
+++ b/.github/workflows/app_interface.yaml
@@ -45,10 +45,6 @@ jobs:
         run: |
           find . -type f -exec sed -i 's/namespace: system/namespace: ${{ env.NAMESPACE }}/' {} \;
         working-directory: app-interface-deployments/internal-services
-      - name: Update image
-        run: |
-          sed -i 's/image: controller:latest/image: quay.io\/redhat-appstudio\/internal-services:${{ github.sha }}/' manager.yaml
-        working-directory: app-interface-deployments/internal-services/manager
       - name: Add users to role binding
         run: |
           users=($USERS)


### PR DESCRIPTION
This commit removes the step from the app_interface workflow that updates the manager image reference in app-interface-deployments. It was updating it to a redhat-appstudio quay image, which is not valid anymore, it was updating a file that is not used, and we are going to handle this with a final pipeline from now on.