### PR TITLE
refactor(RELEASE-1378): remove request from InternalRequest.Spec

### DIFF
--- a/config/crd/bases/appstudio.redhat.com_internalrequests.yaml
+++ b/config/crd/bases/appstudio.redhat.com_internalrequests.yaml
@@ -128,11 +128,6 @@ spec:
                 required:
                 - pipelineRef
                 type: object
-              request:
-                description: Request is the name of the internal internalrequest which
-                  will be translated into a Tekton pipeline
-                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                type: string
               serviceAccount:
                 description: |-
                   ServiceAccount defines the serviceAccount to use in the InternalRequest PipelineRun execution.
@@ -157,6 +152,8 @@ spec:
                       tasks
                     type: string
                 type: object
+            required:
+            - pipeline
             type: object
           status:
             description: InternalRequestStatus defines the observed state of InternalRequest.

--- a/controllers/internalrequest/controller.go
+++ b/controllers/internalrequest/controller.go
@@ -76,7 +76,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		adapter.EnsureRequestINotCompleted,
 		adapter.EnsureConfigIsLoaded, // This operation sets the config in the adapter to be used in other operations.
 		adapter.EnsureRequestIsAllowed,
-		adapter.EnsurePipelineExists, // This operation sets the pipeline in the adapter to be used in other operations.
 		adapter.EnsurePipelineRunIsCreated,
 		adapter.EnsureStatusIsTracked,
 		adapter.EnsurePipelineRunIsDeleted,

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -3,6 +3,7 @@ package loader
 import (
 	"github.com/konflux-ci/internal-services/api/v1alpha1"
 	"github.com/konflux-ci/internal-services/tekton"
+	"github.com/konflux-ci/internal-services/tekton/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -72,13 +73,22 @@ var _ = Describe("Loader", Ordered, func() {
 	})
 
 	createResources = func() {
+		parameterizedPipeline := utils.ParameterizedPipeline{}
+		parameterizedPipeline.PipelineRef = utils.PipelineRef{
+			Resolver: "git",
+			Params: []utils.Param{
+				{Name: "url", Value: "my-url"},
+				{Name: "revision", Value: "my-revision"},
+				{Name: "pathInRepo", Value: "my-path"},
+			},
+		}
 		internalRequest = &v1alpha1.InternalRequest{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "request",
 				Namespace: "default",
 			},
 			Spec: v1alpha1.InternalRequestSpec{
-				Request: "request",
+				Pipeline: &parameterizedPipeline,
 			},
 		}
 		Expect(k8sClient.Create(ctx, internalRequest)).To(Succeed())

--- a/tekton/pipeline_run_test.go
+++ b/tekton/pipeline_run_test.go
@@ -290,13 +290,22 @@ var _ = Describe("PipelineRun", Ordered, func() {
 	})
 
 	createResources = func() {
+		parameterizedPipeline := utils.ParameterizedPipeline{}
+		parameterizedPipeline.PipelineRef = utils.PipelineRef{
+			Resolver: "git",
+			Params: []utils.Param{
+				{Name: "url", Value: "my-url"},
+				{Name: "revision", Value: "my-revision"},
+				{Name: "pathInRepo", Value: "my-path"},
+			},
+		}
 		internalRequest = &v1alpha1.InternalRequest{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "request",
 				Namespace: "default",
 			},
 			Spec: v1alpha1.InternalRequestSpec{
-				Request: "request",
+				Pipeline: &parameterizedPipeline,
 				Params: map[string]string{
 					"foo": "bar",
 					"baz": "qux",

--- a/tekton/utils/pipeline.go
+++ b/tekton/utils/pipeline.go
@@ -16,7 +16,12 @@ limitations under the License.
 
 package utils
 
-import tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+import (
+	"path/filepath"
+	"strings"
+
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+)
 
 // Param defines the parameters for a given resolver in PipelineRef
 type Param struct {
@@ -86,6 +91,21 @@ func (pr *PipelineRef) ToTektonPipelineRef() *tektonv1.PipelineRef {
 	}
 
 	return tektonPipelineRef
+}
+
+// GetPipelineNameFromGitResolver returns the filename as a string from the pathInRepo
+// param used in a git resolver. This is commonly the pipeline name.
+func (prp *ParameterizedPipeline) GetPipelineNameFromGitResolver() string {
+	name := ""
+
+	for _, param := range prp.Params {
+		if param.Name == "pathInRepo" {
+			filename := filepath.Base(param.Value)
+			name = strings.TrimSuffix(filename, filepath.Ext(filename))
+		}
+	}
+
+	return name
 }
 
 // GetTektonParams returns the ParameterizedPipeline []Param as []tektonv1.Param.

--- a/tekton/utils/pipeline_test.go
+++ b/tekton/utils/pipeline_test.go
@@ -93,6 +93,40 @@ var _ = Describe("Pipeline", func() {
 		})
 	})
 
+	When("GetPipelineNameFromGitResolver method is called", func() {
+		It("should return the empty string if there is no pathInRepo parameter", func() {
+			parameterizedPipeline := ParameterizedPipeline{}
+			parameterizedPipeline.Params = []Param{
+				{Name: "parameter1", Value: "value1"},
+			}
+
+			name := parameterizedPipeline.GetPipelineNameFromGitResolver()
+			Expect(name).To(Equal(""))
+		})
+
+		It("should return the proper name when passed a nested yaml", func() {
+			parameterizedPipeline := ParameterizedPipeline{}
+			parameterizedPipeline.Params = []Param{
+				{Name: "parameter1", Value: "value1"},
+				{Name: "pathInRepo", Value: "pipelines/internal/my-pipeline/my-pipeline.yaml"},
+			}
+
+			name := parameterizedPipeline.GetPipelineNameFromGitResolver()
+			Expect(name).To(Equal("my-pipeline"))
+		})
+
+		It("should return the proper name when passed just a filename", func() {
+			parameterizedPipeline := ParameterizedPipeline{}
+			parameterizedPipeline.Params = []Param{
+				{Name: "parameter1", Value: "value1"},
+				{Name: "pathInRepo", Value: "my-pipeline.yaml"},
+			}
+
+			name := parameterizedPipeline.GetPipelineNameFromGitResolver()
+			Expect(name).To(Equal("my-pipeline"))
+		})
+	})
+
 	When("GetTektonParams method is called", func() {
 		It("should return a tekton Param list", func() {
 			parameterizedPipeline := ParameterizedPipeline{}


### PR DESCRIPTION
We used the InternalRequest.Spec.Request field to support cluster references for a pipeline to execute via the InternalRequest. This was not very flexible, and we have since moved to git resolvers. All resolvers are now supported and we no longer use the Spec.Request field, so this commit removes the support for the Request field from the codebase.