### PR TITLE
docs: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ For RHEL users: Extra steps might be required ([Kind - Rootless](https://kind.si
 
 ### Installing `kind`
 ```
-$ go install sigs.k8s.io/kind@v0.19.0
+$ go install sigs.k8s.io/kind@v0.29.0
 ``` 
 
 ### Installing `kubectl`
@@ -225,7 +225,12 @@ kind: InternalRequest
 metadata:
   name: "myrequest"
 spec:
-  request: "sample"
+  pipeline: 
+    pipelineRef:
+      resolver: "cluster"
+      params:
+        - name: "name"
+          value: "sample"
   params:
     foo: bar
     baz: qux
@@ -250,7 +255,12 @@ spec:
   params:
     foo: bar
     baz: qux
-  request: sample
+  pipeline: 
+    pipelineRef:
+      resolver: "cluster"
+      params:
+        - name: "name"
+          value: "sample"
 status:
   completionTime: "2023-01-12T15:34:12Z"
   conditions:


### PR DESCRIPTION
v19 of kind does not work with tekton latest anymore. So, update the docs to say to use v29, which does work with the latest tekton.