### PR TITLE
chore(RELEASE-1477): pin github actions to commit shas

### DIFF
--- a/.github/workflows/app_interface.yaml
+++ b/.github/workflows/app_interface.yaml
@@ -16,11 +16,11 @@ jobs:
       YQ_VERSION: "v4.30.8"
     steps:
       - name: Checkout internal-services repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           path: internal-services
       - name: Checkout app-interface repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           path: app-interface-deployments
           ref: main
@@ -38,7 +38,7 @@ jobs:
           rm -r internal-services/rbac/kustomization.yaml
         working-directory: app-interface-deployments
       - name: Setup yq
-        uses: chrisdickinson/setup-yq@latest
+        uses: chrisdickinson/setup-yq@fa3192edd79d6eb0e4e12de8dde3a0c26f2b853b # latest
         with:
           yq-version: ${{ env.YQ_VERSION }}
       - name: Update namespaces

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -8,14 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version-file: go.mod
       - name: Run tests
         run: make test
       - name: Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5

--- a/.github/workflows/gosec.yaml
+++ b/.github/workflows/gosec.yaml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           fetch-depth: 1
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
+        uses: securego/gosec@5af1117217e476b56a63eaa9ea28eeeb91fbc5ff # master
         with:
           args: -exclude-generated ./...
         env:

--- a/.github/workflows/pr-assigner.yaml
+++ b/.github/workflows/pr-assigner.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign reviewers using shared action
-        uses: konflux-ci/release-service-automations/pr-assigner@main
+        uses: konflux-ci/release-service-automations/pr-assigner@95b18b7c384f4f4d698c17f2476b8ab0cc8cc3ab # main
         with:
           event-type: ${{ github.event.action }}
           pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,15 +13,15 @@ jobs:
       OPERATOR_SDK_VERSION: v1.39.1
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version-file: go.mod
       - name: Cache Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         id: cache-operator-sdk
         with:
           path: ~/cache
@@ -43,7 +43,7 @@ jobs:
           make kustomize controller-gen envtest
       - name: Cache go modules
         id: cache-mod
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -71,7 +71,7 @@ jobs:
             git --no-pager diff ':(exclude)bin/kustomize' ':(exclude)bin/controller-gen'
             exit 1
           fi
-      - uses: dominikh/staticcheck-action@v1.4.0
+      - uses: dominikh/staticcheck-action@024238d2898c874f26d723e7d0ff4308c35589a2 # v1.4.0
         with:
           version: "2025.1.1"
           install-go: false
@@ -87,7 +87,7 @@ jobs:
       - name: Run Go Tests
         run: make test
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5
       - name: Ensure make build succeeds
         run: make build
       - name: Ensure make bundle succeeds
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           fetch-depth: 0
       - name: Check if dockerimage build is working
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
 Prevents supply chain attacks like CVE-2025-30066
 by using immutable action references.