### PR TITLE
feat(RELEASE-1865): store pipelineRun in IR Status

### DIFF
--- a/api/v1alpha1/internalrequest_types.go
+++ b/api/v1alpha1/internalrequest_types.go
@@ -60,6 +60,11 @@ type InternalRequestStatus struct {
 	// +optional
 	CompletionTime *metav1.Time `json:"completionTime,omitempty"`
 
+	// PipelineRun contains the namespaced name of the PipelineRun executed for this InternalRequest
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?\/[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+	// +optional
+	PipelineRun string `json:"pipelineRun,omitempty"`
+
 	// Conditions represent the latest available observations for the internalrequest
 	// +optional
 	Conditions []metav1.Condition `json:"conditions"`

--- a/config/crd/bases/appstudio.redhat.com_internalrequests.yaml
+++ b/config/crd/bases/appstudio.redhat.com_internalrequests.yaml
@@ -221,6 +221,11 @@ spec:
                   - type
                   type: object
                 type: array
+              pipelineRun:
+                description: PipelineRun contains the namespaced name of the PipelineRun
+                  executed for this InternalRequest
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?\/[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
               results:
                 additionalProperties:
                   type: string


### PR DESCRIPTION
This commit adds the pipelineRun field to the InternalRequest Status struct and stores the namespaced name of the pipelinerun there as soon as it is created by the controller.