### PR TITLE
chore: limit go vet threads to 1 to prevent high resource usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ fmt: ## Run go fmt against code.
 
 .PHONY: vet
 vet: ## Run go vet against code.
-	go vet ./...
+	go vet -p 1 ./...
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.


### PR DESCRIPTION
The sealights-unit-tests task was getting OOMKilled. Update go vet to run with -p 1 to prevent high cpu usage.