### PR TITLE
fix: update deprecated task path

### DIFF
--- a/integration-tests/pipelines/simple-e2e-pipeline.yaml
+++ b/integration-tests/pipelines/simple-e2e-pipeline.yaml
@@ -34,9 +34,6 @@ spec:
     - name: machine-type
       description: 'The type of machine to use for the cluster nodes.'
       type: string
-    - name: quality-dashboard-api
-      default: 'none'
-      description: 'Contains the url of the backend to send metrics for quality purposes.'
     - name: oci-container-repo
       default: 'quay.io/konflux-test-storage/konflux-team/internal-services'
       description: The ORAS container used to store all test artifacts.
@@ -50,7 +47,7 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: common/tasks/test-metadata/0.1/test-metadata.yaml
+            value: tasks/test-metadata/0.1/test-metadata.yaml
       params:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)
@@ -496,7 +493,7 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: common/tasks/pull-request-comment/0.1/pull-request-comment.yaml
+            value: tasks/pull-request-comment/0.1/pull-request-comment.yaml
       params:
         - name: test-name
           value: "$(context.pipelineRun.name)"
@@ -522,31 +519,6 @@ spec:
           value: cluster-provision.log
         - name: enable-test-results-analysis
           value: "true"
-    - name: quality-dashboard-upload
-      when:
-        - input: "$(tasks.check-if-test-relevant.results.testRelevant)"
-          operator: in
-          values: ["true"]
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/konflux-ci/tekton-integration-catalog.git
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: common/tasks/quality-dashboard/0.1/quality-dashboard-upload.yaml
-      params:
-        - name: test-name
-          value: "$(context.pipelineRun.name)"
-        - name: oci-container
-          value: "$(params.oci-container-repo):$(context.pipelineRun.name)-local"
-        - name: quality-dashboard-api
-          value: $(params.quality-dashboard-api)
-        - name: pipeline-aggregate-status
-          value: "$(tasks.status)"
-        - name: test-event-type
-          value: "$(tasks.test-metadata.results.test-event-type)"
     - name: store-pipeline-status
       when:
         - input: "$(tasks.check-if-test-relevant.results.testRelevant)"


### PR DESCRIPTION
Updates the deprecated "common/tasks/" path to "tasks/". Path should be updated before 31/10/25 to avoid breaking changes. quality-dashboard is deprecated and should be removed.