### PR TITLE
chore: sync up rbac kustomization.yaml

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -16,3 +16,7 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
+- internalrequest_editor_role.yaml
+- internalrequest_viewer_role.yaml
+- internalservicesconfig_editor_role.yaml
+- internalservicesconfig_viewer_role.yaml


### PR DESCRIPTION
This commit adds the files in the config/rbac directory to the kustomization.yaml file in the same dir that weren't currently present.