### PR TITLE
feat(KONFLUX-13012): cancel PipelineRun when InternalRequest is deleted

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -40,6 +40,7 @@ rules:
   - delete
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - tekton.dev

--- a/controllers/internalrequest/adapter.go
+++ b/controllers/internalrequest/adapter.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // Adapter holds the objects needed to reconcile an InternalRequest.
@@ -56,6 +57,77 @@ func NewAdapter(ctx context.Context, client, internalClient client.Client, inter
 		loader:          loader,
 		logger:          logger,
 	}
+}
+
+// EnsureFinalizerIsAdded is an operation that will ensure that the InternalRequest being processed contains a finalizer.
+func (a *Adapter) EnsureFinalizerIsAdded() (controller.OperationResult, error) {
+	var finalizerFound bool
+	for _, finalizer := range a.internalRequest.GetFinalizers() {
+		if finalizer == tekton.InternalRequestFinalizer {
+			finalizerFound = true
+		}
+	}
+
+	if !finalizerFound {
+		a.logger.Info("Adding Finalizer to the InternalRequest")
+		patch := client.MergeFrom(a.internalRequest.DeepCopy())
+		controllerutil.AddFinalizer(a.internalRequest, tekton.InternalRequestFinalizer)
+		err := a.client.Patch(a.ctx, a.internalRequest, patch)
+
+		return controller.RequeueOnErrorOrContinue(err)
+	}
+
+	return controller.ContinueProcessing()
+}
+
+// EnsureFinalizersAreCalled is an operation that will ensure that finalizers are called whenever the InternalRequest
+// being processed is marked for deletion. Once finalizers get called, the finalizer will be removed and the
+// InternalRequest will go back to the queue, so it gets deleted. If a finalizer function fails its execution or a
+// finalizer fails to be removed, the InternalRequest will be requeued with the error attached.
+func (a *Adapter) EnsureFinalizersAreCalled() (controller.OperationResult, error) {
+	// Check if the InternalRequest is marked for deletion and continue processing other operations otherwise
+	if a.internalRequest.GetDeletionTimestamp() == nil {
+		return controller.ContinueProcessing()
+	}
+
+	if controllerutil.ContainsFinalizer(a.internalRequest, tekton.InternalRequestFinalizer) {
+		if err := a.finalizeInternalRequest(); err != nil {
+			return controller.RequeueWithError(err)
+		}
+
+		patch := client.MergeFrom(a.internalRequest.DeepCopy())
+		controllerutil.RemoveFinalizer(a.internalRequest, tekton.InternalRequestFinalizer)
+		err := a.client.Patch(a.ctx, a.internalRequest, patch)
+		if err != nil {
+			return controller.RequeueWithError(err)
+		}
+	}
+
+	// Requeue the InternalRequest again so it gets deleted and other operations are not executed
+	return controller.Requeue()
+}
+
+// finalizeInternalRequest cancels the PipelineRun associated with the InternalRequest if it is still running.
+func (a *Adapter) finalizeInternalRequest() error {
+	pipelineRun, err := a.loader.GetInternalRequestPipelineRun(a.ctx, a.internalClient, a.internalRequest)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	if pipelineRun != nil && !pipelineRun.IsDone() {
+		a.logger.Info("Cancelling PipelineRun due to InternalRequest deletion",
+			"PipelineRun.Name", pipelineRun.Name, "PipelineRun.Namespace", pipelineRun.Namespace)
+		pipelineRunPatch := client.MergeFrom(pipelineRun.DeepCopy())
+		pipelineRun.Spec.Status = tektonv1.PipelineRunSpecStatusCancelled
+		if err := a.internalClient.Patch(a.ctx, pipelineRun, pipelineRunPatch); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // EnsureConfigIsLoaded is an operation that will load the service InternalServicesConfig from the manager namespace. If not found,

--- a/controllers/internalrequest/adapter_test.go
+++ b/controllers/internalrequest/adapter_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/konflux-ci/internal-services/loader"
+	"github.com/konflux-ci/internal-services/tekton"
 	"github.com/konflux-ci/internal-services/tekton/utils"
 	toolkit "github.com/konflux-ci/operator-toolkit/loader"
 
@@ -33,6 +34,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 var _ = Describe("PipelineRun", Ordered, func() {
@@ -152,6 +155,137 @@ var _ = Describe("PipelineRun", Ordered, func() {
 			result, err := adapter.EnsurePipelineRunIsDeleted()
 			Expect(!result.CancelRequest && !result.RequeueRequest).To(BeTrue())
 			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("When calling EnsureFinalizersAreCalled", func() {
+		AfterEach(func() {
+			deleteResources()
+		})
+
+		BeforeEach(func() {
+			createResources()
+		})
+
+		It("should do nothing if the InternalRequest is not set to be deleted", func() {
+			result, err := adapter.EnsureFinalizersAreCalled()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(!result.CancelRequest && !result.RequeueRequest).To(BeTrue())
+		})
+
+		It("should requeue if finalizeInternalRequest fails", func() {
+			adapter.internalRequestPipeline = pipeline
+			adapter.internalRequest.MarkRunning()
+
+			result, err := adapter.EnsureFinalizerIsAdded()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(adapter.internalRequest.Finalizers).To(HaveLen(1))
+
+			Expect(k8sClient.Delete(ctx, adapter.internalRequest)).To(Succeed())
+			adapter.internalRequest, err = adapter.loader.GetInternalRequest(
+				ctx, k8sClient, adapter.internalRequest.Name, adapter.internalRequest.Namespace)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(adapter.internalRequest.DeletionTimestamp).NotTo(BeNil())
+
+			adapter.ctx = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.InternalRequestPipelineRunContextKey,
+					Err:        fmt.Errorf("some error"),
+				},
+			})
+			result, err = adapter.EnsureFinalizersAreCalled()
+			Expect(!result.CancelRequest && result.RequeueRequest).To(BeTrue())
+			Expect(err).NotTo(BeNil())
+		})
+
+		It("should finalize the InternalRequest if it's set to be deleted and it has a finalizer", func() {
+			adapter.internalRequestPipeline = pipeline
+			adapter.internalRequest.MarkRunning()
+
+			result, err := adapter.EnsureFinalizerIsAdded()
+			Expect(!result.RequeueRequest && result.CancelRequest).To(BeFalse())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(adapter.internalRequest.Finalizers).To(HaveLen(1))
+
+			pipelineRun, err := adapter.createInternalRequestPipelineRun()
+			Expect(pipelineRun).NotTo(BeNil())
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Delete(ctx, adapter.internalRequest)).To(Succeed())
+			adapter.internalRequest, err = adapter.loader.GetInternalRequest(
+				ctx, k8sClient, adapter.internalRequest.Name, adapter.internalRequest.Namespace)
+			Expect(adapter.internalRequest).NotTo(BeNil())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(adapter.internalRequest.DeletionTimestamp).NotTo(BeNil())
+
+			result, err = adapter.EnsureFinalizersAreCalled()
+			Expect(result.RequeueRequest && !result.CancelRequest).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+
+			cancelledPipelineRun, err := adapter.loader.GetInternalRequestPipelineRun(
+				ctx, k8sClient, adapter.internalRequest)
+			Expect(err).NotTo(HaveOccurred())
+			if cancelledPipelineRun != nil {
+				Expect(string(cancelledPipelineRun.Spec.Status)).To(
+					Equal(string(tektonv1.PipelineRunSpecStatusCancelled)))
+			}
+
+			_, err = adapter.loader.GetInternalRequest(ctx, k8sClient, adapter.internalRequest.Name, adapter.internalRequest.Namespace)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("should finalize without error when no PipelineRun exists", func() {
+			adapter.internalRequest.MarkRunning()
+
+			result, err := adapter.EnsureFinalizerIsAdded()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(adapter.internalRequest.Finalizers).To(HaveLen(1))
+
+			Expect(k8sClient.Delete(ctx, adapter.internalRequest)).To(Succeed())
+			adapter.internalRequest, err = adapter.loader.GetInternalRequest(
+				ctx, k8sClient, adapter.internalRequest.Name, adapter.internalRequest.Namespace)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(adapter.internalRequest.DeletionTimestamp).NotTo(BeNil())
+
+			result, err = adapter.EnsureFinalizersAreCalled()
+			Expect(result.RequeueRequest && !result.CancelRequest).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = adapter.loader.GetInternalRequest(ctx, k8sClient, adapter.internalRequest.Name, adapter.internalRequest.Namespace)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+
+	Context("When calling EnsureFinalizerIsAdded", func() {
+		AfterEach(func() {
+			deleteResources()
+		})
+
+		BeforeEach(func() {
+			createResources()
+		})
+
+		It("should add a finalizer when one does not exist", func() {
+			Expect(adapter.internalRequest.Finalizers).To(BeEmpty())
+			result, err := adapter.EnsureFinalizerIsAdded()
+			Expect(!result.CancelRequest && !result.RequeueRequest).To(BeTrue())
+			Expect(err).To(BeNil())
+			Expect(adapter.internalRequest.Finalizers).To(HaveLen(1))
+			Expect(adapter.internalRequest.Finalizers[0]).To(Equal(tekton.InternalRequestFinalizer))
+		})
+
+		It("should not add a duplicate finalizer", func() {
+			result, err := adapter.EnsureFinalizerIsAdded()
+			Expect(err).To(BeNil())
+			Expect(!result.CancelRequest && !result.RequeueRequest).To(BeTrue())
+			Expect(adapter.internalRequest.Finalizers).To(HaveLen(1))
+
+			result, err = adapter.EnsureFinalizerIsAdded()
+			Expect(err).To(BeNil())
+			Expect(!result.CancelRequest && !result.RequeueRequest).To(BeTrue())
+			Expect(adapter.internalRequest.Finalizers).To(HaveLen(1))
 		})
 	})
 
@@ -452,7 +586,15 @@ var _ = Describe("PipelineRun", Ordered, func() {
 
 	deleteResources = func() {
 		_ = k8sClient.Delete(ctx, adapter.internalServicesConfig)
-		Expect(k8sClient.Delete(ctx, adapter.internalRequest)).To(Succeed())
+
+		// Remove any finalizers before deleting the InternalRequest so it doesn't get stuck
+		if controllerutil.ContainsFinalizer(adapter.internalRequest, tekton.InternalRequestFinalizer) {
+			patch := client.MergeFrom(adapter.internalRequest.DeepCopy())
+			controllerutil.RemoveFinalizer(adapter.internalRequest, tekton.InternalRequestFinalizer)
+			_ = k8sClient.Patch(ctx, adapter.internalRequest, patch)
+		}
+
+		_ = k8sClient.Delete(ctx, adapter.internalRequest)
 		Expect(k8sClient.Delete(ctx, pipeline)).To(Succeed())
 		err := k8sClient.DeleteAllOf(ctx, &tektonv1.PipelineRun{})
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())

--- a/controllers/internalrequest/controller.go
+++ b/controllers/internalrequest/controller.go
@@ -52,7 +52,7 @@ type Reconciler struct {
 // +kubebuilder:rbac:groups=appstudio.redhat.com,resources=internalrequests/finalizers,verbs=update
 // +kubebuilder:rbac:groups=appstudio.redhat.com,resources=internalservicesconfigs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=tekton.dev,resources=pipelines,verbs=get;list;watch
-// +kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns,verbs=get;list;watch;create;delete
+// +kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns,verbs=get;list;watch;create;delete;patch
 // +kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns/status,verbs=get
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -73,6 +73,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	adapter := NewAdapter(ctx, r.Client, r.InternalClient, internalRequest, loader.NewLoader(), logger)
 
 	return controller.ReconcileHandler([]controller.Operation{
+		adapter.EnsureFinalizersAreCalled,
+		adapter.EnsureFinalizerIsAdded,
 		adapter.EnsureRequestINotCompleted,
 		adapter.EnsureConfigIsLoaded, // This operation sets the config in the adapter to be used in other operations.
 		adapter.EnsureRequestIsAllowed,

--- a/integration-tests/pipelines/simple-e2e-pipeline.yaml
+++ b/integration-tests/pipelines/simple-e2e-pipeline.yaml
@@ -156,6 +156,10 @@ spec:
           value: $(params.oci-container-repo):$(context.pipelineRun.name)-remote
         - name: credentials-secret-name
           value: $(params.konflux-test-infra-secret)
+        - name: spot
+          value: "false"
+        - name: compute-sizes
+          value: "t3a.2xlarge,m5a.2xlarge,m5ad.2xlarge,m6a.2xlarge,m7a.2xlarge,m8a.2xlarge"
     - name: provision-local-kind-cluster
       runAfter:
         - check-if-test-relevant
@@ -193,6 +197,10 @@ spec:
           value: $(params.oci-container-repo):$(context.pipelineRun.name)-local
         - name: credentials-secret-name
           value: $(params.konflux-test-infra-secret)
+        - name: spot
+          value: "false"
+        - name: compute-sizes
+          value: "t3a.2xlarge,m5a.2xlarge,m5ad.2xlarge,m6a.2xlarge,m7a.2xlarge,m8a.2xlarge"
     - name: setup-remote-cluster
       runAfter:
         - provision-remote-kind-cluster

--- a/tekton/pipeline_run.go
+++ b/tekton/pipeline_run.go
@@ -34,6 +34,10 @@ const (
 	// internalRequestLabelPrefix is the prefix of the internal request labels
 	internalRequestLabelPrefix = "internal-services.appstudio.openshift.io"
 
+	// InternalRequestFinalizer is the finalizer added to InternalRequests to ensure the
+	// associated PipelineRun is cancelled before the InternalRequest is deleted.
+	InternalRequestFinalizer = internalRequestLabelPrefix + "/pipelinerun-cleanup"
+
 	// PipelineTypeRelease is the type for PipelineRuns created to run a release Pipeline
 	PipelineTypeRelease = "release"
 )


### PR DESCRIPTION
When an InternalRequest CR is deleted (e.g. by cleanup-internal-requests or during managed task retries), the associated PipelineRun on the internal cluster was left running as an orphan.
This adds a finalizer to InternalRequests so the controller can cancel the associated PipelineRun before the CR is deleted. The pattern follows the existing finalizer implementation in the release-service controller. Changes:
- Add InternalRequestFinalizer constant in tekton/pipeline_run.go
- Add EnsureFinalizerIsAdded to attach finalizer on first reconcile
- Add EnsureFinalizersAreCalled to cancel PipelineRun on deletion
- Add finalizeInternalRequest to handle PipelineRun cancellation
- Add tests modeled after release-service adapter_test.go

Assisted-by: Cursor AI