### PR TITLE
chore(RELEASE-2405): add shared renovate preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>konflux-ci/release-service-automations//mintMaker/default"]
+}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -135,4 +135,4 @@ jobs:
       - uses: actions/checkout@v6
       - uses: konflux-ci/renovate-config-validator-action@main
         with:
-          config_file: renovate.json
+          config_file: .github/renovate.json

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "tekton": {
-    "schedule": ["* 0-4 * * *"]
-  }
-}


### PR DESCRIPTION
Move renovate.json to .github/ and extend the base preset from release-service-automations.
Jira: RELEASE-2405

depends on https://github.com/konflux-ci/release-service-automations/pull/18