### PR TITLE
fix(KONFLUX-13012): limit parallelism to prevent OOM kills

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,9 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
+	# -p 1 limits parallel package compilation to prevent simultaneous linker invocations
+	# from exhausting pod memory (OOM kill) in CI environments with constrained resources
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -p 1 ./... -coverprofile cover.out
 
 ##@ Build
 


### PR DESCRIPTION
The CI unit-test step has no memory limits. Running go test ./... without -p 1 compiles and links all packages in parallel, causing simultaneous linker invocations that together exhaust the pod's available memory. The kernel OOM killer then sends SIGKILL to whichever linker processes are running at peak, producing:

  /usr/lib/golang/pkg/tool/linux_amd64/link: signal: killed

The failing package varies between runs (loader, tekton, api/v1alpha1, controllers/internalrequest) because the OOM killer fires whenever total memory peaks, hitting whichever processes are linking at that moment.

Setting -p 1 serializes package compilation so only one linker runs at a time, eliminating the memory spike. go vet already uses -p 1 for the same reason.

Assisted-by: Cursor AI