### PR TITLE
feat(RELEASE-2641): copy labels from IR to PLR

### DIFF
--- a/tekton/pipeline_run.go
+++ b/tekton/pipeline_run.go
@@ -18,6 +18,7 @@ package tekton
 
 import (
 	"fmt"
+	"maps"
 	"reflect"
 	"strings"
 
@@ -87,11 +88,13 @@ func (i *InternalRequestPipelineRun) WithInternalRequest(internalRequest *v1alph
 		})
 	}
 
-	i.ObjectMeta.Labels = map[string]string{
-		InternalRequestNameLabel:      internalRequest.Name,
-		InternalRequestNamespaceLabel: internalRequest.Namespace,
-		metadata.PipelinesTypeLabel:   PipelineTypeRelease,
-	}
+	i.ObjectMeta.Labels = make(map[string]string)
+	maps.Copy(i.ObjectMeta.Labels, internalRequest.Labels)
+
+	// System labels override any user-provided labels
+	i.ObjectMeta.Labels[InternalRequestNameLabel] = internalRequest.Name
+	i.ObjectMeta.Labels[InternalRequestNamespaceLabel] = internalRequest.Namespace
+	i.ObjectMeta.Labels[metadata.PipelinesTypeLabel] = PipelineTypeRelease
 
 	if internalRequest.Spec.Timeouts != (tektonv1.TimeoutFields{}) {
 		i.Spec.Timeouts = &internalRequest.Spec.Timeouts

--- a/tekton/pipeline_run_test.go
+++ b/tekton/pipeline_run_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/konflux-ci/internal-services/api/v1alpha1"
+	"github.com/konflux-ci/internal-services/metadata"
 	"github.com/konflux-ci/internal-services/tekton/utils"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -94,6 +95,42 @@ var _ = Describe("PipelineRun", Ordered, func() {
 
 			Expect(newInternalRequestPipelineRun.Labels[InternalRequestNameLabel]).To(Equal(internalRequest.Name))
 			Expect(newInternalRequestPipelineRun.Labels[InternalRequestNamespaceLabel]).To(Equal(internalRequest.Namespace))
+		})
+
+		It("should copy all labels from the InternalRequest to the PipelineRun", func() {
+			newInternalRequest := internalRequest.DeepCopy()
+			newInternalRequest.Labels = map[string]string{
+				"app.kubernetes.io/name":      "test-app",
+				"app.kubernetes.io/component": "backend",
+				"custom-label":                "custom-value",
+			}
+
+			newInternalRequestPipelineRun := NewInternalRequestPipelineRun(internalServicesConfig)
+			newInternalRequestPipelineRun.WithInternalRequest(newInternalRequest)
+
+			Expect(newInternalRequestPipelineRun.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "test-app"))
+			Expect(newInternalRequestPipelineRun.Labels).To(HaveKeyWithValue("app.kubernetes.io/component", "backend"))
+			Expect(newInternalRequestPipelineRun.Labels).To(HaveKeyWithValue("custom-label", "custom-value"))
+			Expect(newInternalRequestPipelineRun.Labels[InternalRequestNameLabel]).To(Equal(newInternalRequest.Name))
+			Expect(newInternalRequestPipelineRun.Labels[InternalRequestNamespaceLabel]).To(Equal(newInternalRequest.Namespace))
+		})
+
+		It("should ensure system labels cannot be overwritten by InternalRequest labels", func() {
+			newInternalRequest := internalRequest.DeepCopy()
+			newInternalRequest.Labels = map[string]string{
+				InternalRequestNameLabel:      "user-provided-name",
+				InternalRequestNamespaceLabel: "user-provided-namespace",
+				metadata.PipelinesTypeLabel:   "user-provided-type",
+				"custom-label":                "custom-value",
+			}
+
+			newInternalRequestPipelineRun := NewInternalRequestPipelineRun(internalServicesConfig)
+			newInternalRequestPipelineRun.WithInternalRequest(newInternalRequest)
+
+			Expect(newInternalRequestPipelineRun.Labels[InternalRequestNameLabel]).To(Equal(newInternalRequest.Name))
+			Expect(newInternalRequestPipelineRun.Labels[InternalRequestNamespaceLabel]).To(Equal(newInternalRequest.Namespace))
+			Expect(newInternalRequestPipelineRun.Labels[metadata.PipelinesTypeLabel]).To(Equal(PipelineTypeRelease))
+			Expect(newInternalRequestPipelineRun.Labels).To(HaveKeyWithValue("custom-label", "custom-value"))
 		})
 
 		It("should contain the timeout values", func() {


### PR DESCRIPTION
When creating a PipelineRun from an InternalRequest, copy all labels from the InternalRequest resource to the PipelineRun. This allows custom labels (e.g., app.kubernetes.io/* labels) to be propagated for resource organization, monitoring, and filtering.
