### PR TITLE
fix: pin git-clone-oci-ta to trusted 0.2 digest

### DIFF
--- a/.tekton/internal-services-pull-request.yaml
+++ b/.tekton/internal-services-pull-request.yaml
@@ -159,7 +159,7 @@ spec:
         - name: name
           value: git-clone-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2@sha256:89da85c1508b3a2b7ad884c1215b9fd3a7d9e28c2335aca6750948d129707035
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2@sha256:e46c6578476caa8814ffd3322deeb9533c5b57396aedc758e554a663ba984eee
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/internal-services-push.yaml
+++ b/.tekton/internal-services-push.yaml
@@ -155,7 +155,7 @@ spec:
         - name: name
           value: git-clone-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2@sha256:89da85c1508b3a2b7ad884c1215b9fd3a7d9e28c2335aca6750948d129707035
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2@sha256:e46c6578476caa8814ffd3322deeb9533c5b57396aedc758e554a663ba984eee
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
MintMaker #846 bumped git-clone-oci-ta to a digest not yet in data-acceptable-bundles, causing Conforma/EC failures. Pin to the current trusted digest for task-git-clone-oci-ta:0.2.