### PR TITLE
fix(RELEASE-2720): add git resolver URL allowlist

### DIFF
--- a/api/v1alpha1/internalservicesconfig_types.go
+++ b/api/v1alpha1/internalservicesconfig_types.go
@@ -28,6 +28,12 @@ type InternalServicesConfigSpec struct {
 	// +optional
 	AllowList []string `json:"allowList,omitempty"`
 
+	// AllowedGitResolverURLs is the list of git resolver URLs allowed for pipeline references.
+	// When non-empty and the resolver is "git", only requests with a URL matching one of these
+	// entries will be allowed. When empty, all git resolver URLs are permitted.
+	// +optional
+	AllowedGitResolverURLs []string `json:"allowedGitResolverURLs,omitempty"`
+
 	// Debug sets the operator to run in debug mode. In this mode, PipelineRuns and PVCs will not be removed
 	// +optional
 	Debug bool `json:"debug,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -217,6 +217,11 @@ func (in *InternalServicesConfigSpec) DeepCopyInto(out *InternalServicesConfigSp
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.AllowedGitResolverURLs != nil {
+		in, out := &in.AllowedGitResolverURLs, &out.AllowedGitResolverURLs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	out.VolumeClaim = in.VolumeClaim
 }
 

--- a/config/crd/bases/appstudio.redhat.com_internalservicesconfigs.yaml
+++ b/config/crd/bases/appstudio.redhat.com_internalservicesconfigs.yaml
@@ -46,6 +46,14 @@ spec:
                 items:
                   type: string
                 type: array
+              allowedGitResolverURLs:
+                description: |-
+                  AllowedGitResolverURLs is the list of git resolver URLs allowed for pipeline references.
+                  When non-empty and the resolver is "git", only requests with a URL matching one of these
+                  entries will be allowed. When empty, all git resolver URLs are permitted.
+                items:
+                  type: string
+                type: array
               debug:
                 description: Debug sets the operator to run in debug mode. In this
                   mode, PipelineRuns and PVCs will not be removed

--- a/controllers/internalrequest/adapter.go
+++ b/controllers/internalrequest/adapter.go
@@ -220,13 +220,43 @@ func (a *Adapter) EnsurePipelineRunIsDeleted() (controller.OperationResult, erro
 func (a *Adapter) EnsureRequestIsAllowed() (controller.OperationResult, error) {
 	for _, namespace := range a.internalServicesConfig.Spec.AllowList {
 		if namespace == a.internalRequest.Namespace {
-			return controller.ContinueProcessing()
+			return a.ensureGitResolverURLIsAllowed()
 		}
 	}
 
 	patch := client.MergeFrom(a.internalRequest.DeepCopy())
 	a.internalRequest.MarkRejected(
 		fmt.Sprintf("the internal request namespace (%s) is not in the allow list", a.internalRequest.Namespace),
+	)
+	return controller.RequeueOnErrorOrStop(a.client.Status().Patch(a.ctx, a.internalRequest, patch))
+}
+
+// ensureGitResolverURLIsAllowed checks whether the git resolver URL in the InternalRequest
+// matches an entry in the AllowedGitResolverURLs list. If the resolver is not "git" or the
+// list is empty, all requests are allowed.
+func (a *Adapter) ensureGitResolverURLIsAllowed() (controller.OperationResult, error) {
+	if a.internalRequest.Spec.Pipeline.PipelineRef.Resolver != "git" ||
+		len(a.internalServicesConfig.Spec.AllowedGitResolverURLs) == 0 {
+		return controller.ContinueProcessing()
+	}
+
+	var url string
+	for _, param := range a.internalRequest.Spec.Pipeline.PipelineRef.Params {
+		if param.Name == "url" {
+			url = param.Value
+			break
+		}
+	}
+
+	for _, allowedURL := range a.internalServicesConfig.Spec.AllowedGitResolverURLs {
+		if url == allowedURL {
+			return controller.ContinueProcessing()
+		}
+	}
+
+	patch := client.MergeFrom(a.internalRequest.DeepCopy())
+	a.internalRequest.MarkRejected(
+		fmt.Sprintf("the pipeline git resolver URL (%s) is not in the allowed list: %v", url, a.internalServicesConfig.Spec.AllowedGitResolverURLs),
 	)
 	return controller.RequeueOnErrorOrStop(a.client.Status().Patch(a.ctx, a.internalRequest, patch))
 }

--- a/controllers/internalrequest/adapter_test.go
+++ b/controllers/internalrequest/adapter_test.go
@@ -466,6 +466,65 @@ var _ = Describe("PipelineRun", Ordered, func() {
 			Expect(adapter.internalRequest.Status.Conditions[0].Reason).To(Equal(string(v1alpha1.RejectedReason)))
 			Expect(adapter.internalRequest.Status.Conditions[0].Message).To(ContainSubstring("not in the allow list"))
 		})
+
+		It("should allow when allowedGitResolverURLs is empty", func() {
+			Expect(k8sClient.Delete(ctx, adapter.internalServicesConfig)).To(Succeed())
+
+			adapter.internalServicesConfig = &v1alpha1.InternalServicesConfig{
+				Spec: v1alpha1.InternalServicesConfigSpec{
+					AllowList: []string{"default"},
+				},
+			}
+			result, err := adapter.EnsureRequestIsAllowed()
+			Expect(!result.CancelRequest && !result.RequeueRequest).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
+
+		It("should allow when the git resolver URL matches an entry in allowedGitResolverURLs", func() {
+			Expect(k8sClient.Delete(ctx, adapter.internalServicesConfig)).To(Succeed())
+
+			adapter.internalServicesConfig = &v1alpha1.InternalServicesConfig{
+				Spec: v1alpha1.InternalServicesConfigSpec{
+					AllowList:              []string{"default"},
+					AllowedGitResolverURLs: []string{"my-url", "other-url"},
+				},
+			}
+			result, err := adapter.EnsureRequestIsAllowed()
+			Expect(!result.CancelRequest && !result.RequeueRequest).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
+
+		It("should reject when the git resolver URL does not match any entry in allowedGitResolverURLs", func() {
+			Expect(k8sClient.Delete(ctx, adapter.internalServicesConfig)).To(Succeed())
+
+			adapter.internalServicesConfig = &v1alpha1.InternalServicesConfig{
+				Spec: v1alpha1.InternalServicesConfigSpec{
+					AllowList:              []string{"default"},
+					AllowedGitResolverURLs: []string{"other-url"},
+				},
+			}
+			result, err := adapter.EnsureRequestIsAllowed()
+			Expect(result.CancelRequest && !result.RequeueRequest).To(BeTrue())
+			Expect(err).To(BeNil())
+			Expect(adapter.internalRequest.Status.Conditions).To(HaveLen(1))
+			Expect(adapter.internalRequest.Status.Conditions[0].Reason).To(Equal(string(v1alpha1.RejectedReason)))
+			Expect(adapter.internalRequest.Status.Conditions[0].Message).To(ContainSubstring("not in the allowed list"))
+		})
+
+		It("should skip git resolver URL check when resolver is not git", func() {
+			Expect(k8sClient.Delete(ctx, adapter.internalServicesConfig)).To(Succeed())
+
+			adapter.internalServicesConfig = &v1alpha1.InternalServicesConfig{
+				Spec: v1alpha1.InternalServicesConfigSpec{
+					AllowList:              []string{"default"},
+					AllowedGitResolverURLs: []string{"other-url"},
+				},
+			}
+			adapter.internalRequest.Spec.Pipeline.PipelineRef.Resolver = "cluster"
+			result, err := adapter.EnsureRequestIsAllowed()
+			Expect(!result.CancelRequest && !result.RequeueRequest).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
 	})
 
 	Context("When calling EnsureRequestINotCompleted", func() {


### PR DESCRIPTION
Add allowedGitResolverURLs field to config spec, to restrict which git repositories can be used for pipeline references.

When the list is non-empty and the resolver is "git", only requests with a URL matching one of the entries will be allowed. When empty, all URLs are permitted.

Assisted-by: Claude Code